### PR TITLE
Fix text disappearing when hovering over widget buttons

### DIFF
--- a/Lightsout/Lightsout_V.2.0 (dark).qss
+++ b/Lightsout/Lightsout_V.2.0 (dark).qss
@@ -365,12 +365,11 @@ QToolButton::disabled {
 }
 QToolButton::hover {
 
-	padding-top: 10px;
-	padding-bottom: 10px;
-	background-color: #212121;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	background-color: #4b4b4b;
 	border-radius: 8px;
 	transition: 0.5s;
-	color: #212121;
 	transition: 0.5s;
 }
 


### PR DESCRIPTION
Fixes #7
Tested on a 1440p display.
In the video, when the mouse seemingly interacts with invisible objects, I'm changing from original to fixed theme 😆 but the settings window didn't get captured.


https://github.com/Humanoidear/Lightsout/assets/32672927/77f6826c-bc60-4181-9c7d-ae5c53b4a988

